### PR TITLE
Add test coverage to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,9 @@ name: 'Build and Test'
 on: [push, pull_request, workflow_dispatch]
 
 env:
+  COVERAGE_CORE: sysmon
+  FORCE_COLOR: 1
   PIP_DISABLE_PIP_VERSION_CHECK: true
-  PIP_NO_COLOR: true
   PIP_NO_INPUT: true
   PIP_PROGRESS_BAR: off
   PIP_REQUIRE_VIRTUALENV: false
@@ -38,13 +39,22 @@ jobs:
       run: python -m pip install pymsbuild
 
     - name: 'Install test runner'
-      run: python -m pip install pytest
+      run: python -m pip install pytest pytest-cov
 
     - name: 'Build test module'
       run: python -m pymsbuild -c _msbuild_test.py
 
     - name: 'Run pre-test'
-      run: python -m pytest -vv
+      shell: bash
+      run: |
+        python -m pytest -vv \
+          --cov src \
+          --cov tests \
+          --cov-report term \
+          --cov-report xml
+
+    - name: 'Upload coverage'
+      uses: codecov/codecov-action@v5
 
     - name: 'Build package'
       run: python make.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Python Install Manager
 
+[![Codecov](https://codecov.io/gh/python/pymanager/graph/badge.svg)](https://codecov.io/gh/python/pymanager)
+
 This is the source code for the Python Install Manager app.
 
 For information about how to use the Python install manager,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
 [build-system]
 requires = ['pymsbuild>=1.1.1,<2.0']
 build-backend = "pymsbuild"
+
+[tool.coverage.run]
+branch = true
+disable_warnings = [
+  "no-sysmon",
+]
+omit = [
+  "src/manage/__main__.py",
+]
+
+[tool.coverage.html]
+show_contexts = true

--- a/tests/test_installs.py
+++ b/tests/test_installs.py
@@ -120,7 +120,7 @@ def test_get_install_to_run_with_platform(patched_installs):
     assert i["executable"].match("python.exe")
 
 
-def test_get_install_to_run_with_platform(patched_installs):
+def test_get_install_to_run_with_platform_windowed(patched_installs):
     i = installs.get_install_to_run("<none>", None, "1.0-32", windowed=True)
     assert i["id"] == "PythonCore-1.0-32"
     assert i["executable"].match("pythonw.exe")


### PR DESCRIPTION
Helps https://github.com/python/pymanager/issues/7.

Run tests with coverage,  and send to the terminal and Codecov, so we get reports like https://github.com/hugovk/pymanager/actions/runs/14727134371/job/41332386214#step:8:218 and https://app.codecov.io/gh/hugovk/pymanager/tree/coverage

Fix a reused test name that meant the test wasn't run, found from looking at test coverage results.
