### PR TITLE
Switch default tag to plain '3.14'

### DIFF
--- a/src/manage/commands.py
+++ b/src/manage/commands.py
@@ -22,7 +22,7 @@ LOGGER = logging.LOGGER
 # or check out the docs for administrative controls:
 #    https://docs.python.org/using/windows
 DEFAULT_SOURCE_URL = "https://www.python.org/ftp/python/index-windows.json"
-DEFAULT_TAG = "3.14-dev"
+DEFAULT_TAG = "3.14"
 
 
 COPYRIGHT = f"""Python installation manager {__version__}


### PR DESCRIPTION
This should fix the issue on first launch where an existing install is found but not run.

As long as only prerelease 3.14s are available, it will install those. Once we have a stable 3.14 it should prefer that, even if there are "newer" prereleases.