### PR TITLE
Fixes #11 Detect and overwrite corrupt PEP 514 registry entries

### DIFF
--- a/_msbuild.py
+++ b/_msbuild.py
@@ -83,6 +83,7 @@ NATIVE_PYD = DllPackage(
     CFunction('fd_supports_vt100'),
     CFunction('date_as_str'),
     CFunction('datetime_as_str'),
+    CFunction('reg_rename_key'),
     source='src/_native',
     RootNamespace='_native',
 )

--- a/_msbuild_test.py
+++ b/_msbuild_test.py
@@ -49,6 +49,7 @@ PACKAGE = Package('src',
         CFunction('fd_supports_vt100'),
         CFunction('date_as_str'),
         CFunction('datetime_as_str'),
+        CFunction('reg_rename_key'),
         source='src/_native',
     ),
 )

--- a/src/_native/misc.cpp
+++ b/src/_native/misc.cpp
@@ -95,4 +95,28 @@ PyObject *datetime_as_str(PyObject *, PyObject *, PyObject *) {
     return PyUnicode_FromWideChar(buffer, cch - 1);
 }
 
+PyObject *reg_rename_key(PyObject *, PyObject *args, PyObject *kwargs) {
+    static const char * keywords[] = {"handle", "name1", "name2", NULL};
+    PyObject *handle_obj;
+    wchar_t *name1 = NULL;
+    wchar_t *name2 = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO&O&:reg_rename_key", keywords,
+        &handle_obj, as_utf16, &name1, as_utf16, &name2)) {
+        return NULL;
+    }
+    PyObject *r = NULL;
+    HKEY h;
+    if (PyLong_AsNativeBytes(handle_obj, &h, sizeof(h), -1) >= 0) {
+        int err = (int)RegRenameKey(h, name1, name2);
+        if (!err) {
+            r = Py_GetConstant(Py_CONSTANT_NONE);
+        } else {
+            PyErr_SetFromWindowsErr(err);
+        }
+    }
+    PyMem_Free(name1);
+    PyMem_Free(name2);
+    return r;
+}
+
 }

--- a/src/manage/pep514utils.py
+++ b/src/manage/pep514utils.py
@@ -201,6 +201,7 @@ def _is_tag_managed(company_key, tag_name, *, creating=False):
             except PermissionError:
                 LOGGER.debug("Failed to rename %s to %s", orig_name, new_name,
                              exc_info=True)
+                # Continue, hopefully the next new_name is available
             except OSError:
                 LOGGER.debug("Unexpected error while renaming %s to %s",
                              orig_name, new_name, exc_info=True)

--- a/tests/test_pep514utils.py
+++ b/tests/test_pep514utils.py
@@ -1,0 +1,54 @@
+import pytest
+import winreg
+
+from manage import pep514utils
+
+REG_TEST_ROOT = r"Software\Python\PyManagerTesting"
+
+@pytest.fixture(scope='function')
+def registry():
+    try:
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, REG_TEST_ROOT) as key:
+            yield key
+    finally:
+        pep514utils._reg_rmtree(winreg.HKEY_CURRENT_USER, REG_TEST_ROOT)
+
+
+def init_reg(registry, **keys):
+    for k, v in keys.items():
+        if isinstance(v, dict):
+            with winreg.CreateKey(registry, k) as subkey:
+                init_reg(subkey, **v)
+        elif isinstance(v, str):
+            winreg.SetValueEx(registry, k, None, winreg.REG_SZ, v)
+        elif isinstance(v, (bytes, bytearray)):
+            winreg.SetValueEx(registry, k, None, winreg.REG_BINARY, v)
+        elif isinstance(v, int):
+            if v.bit_count() < 32:
+                winreg.SetValueEx(registry, k, None, winreg.REG_DWORD, v)
+            else:
+                winreg.SetValueEx(registry, k, None, winreg.REG_QWORD, v)
+        else:
+            raise TypeError("unsupported type in registry")
+
+
+def test_is_tag_managed(registry, tmp_path):
+    init_reg(registry, Company={
+        "1.0": {"InstallPath": {"": str(tmp_path)}},
+        "2.0": {"InstallPath": {"": str(tmp_path)}, "ManagedByPyManager": 0},
+        "2.1": {"InstallPath": {"": str(tmp_path)}, "ManagedByPyManager": 1},
+        "3.0": {"InstallPath": {"": str(tmp_path / "missing")}},
+        "3.0.0": {"": "Just in the way here"},
+        "3.0.1": {"": "Also in the way here"},
+    })
+
+    assert not pep514utils._is_tag_managed(registry, r"Company\1.0")
+    assert not pep514utils._is_tag_managed(registry, r"Company\2.0")
+    assert pep514utils._is_tag_managed(registry, r"Company\2.1")
+
+    assert not pep514utils._is_tag_managed(registry, r"Company\3.0")
+    with pytest.raises(FileNotFoundError):
+        winreg.OpenKey(registry, r"Company\3.0.2")
+    assert pep514utils._is_tag_managed(registry, r"Company\3.0", creating=True)
+    with winreg.OpenKey(registry, r"Company\3.0.2"):
+        pass


### PR DESCRIPTION
pep514utils now attempts to move existing registry entries if they appear invalid. This should reduce the likelihood of bad MSI uninstalls causing repeated warnings for the rest of time, at a small risk of corrupting (intentionally useless) entries.