### PR TITLE
Fixes #24: Ensure platform override works on prereleases.

### DIFF
--- a/src/manage/installs.py
+++ b/src/manage/installs.py
@@ -210,13 +210,17 @@ def get_matching_install_tags(
     # If none or only prereleases, keep them all
     if default_platform:
         default_platform = default_platform.casefold()
+        all_pre = all(Version(i["sort-version"]).is_prerelease for i, t in best)
         best2 = best
         best = [(i, t) for i, t in best
                 if i.get("__any-platform")
                 or t["tag"].casefold().endswith(default_platform)]
         LOGGER.debug("default_platform '%s' matched %s %s", default_platform,
                      len(best), "install" if len(best) == 1 else "installs")
-        if not best or all(Version(i["sort-version"]).is_prerelease for i, t in best):
+        if (
+            not best or
+            (not all_pre and all(Version(i["sort-version"]).is_prerelease for i, t in best))
+        ):
             LOGGER.debug("Reusing unfiltered list")
             best = best2
 

--- a/tests/test_indexutils.py
+++ b/tests/test_indexutils.py
@@ -180,4 +180,6 @@ def test_select_package():
         ],
     })
     assert select_package([index], "3.13", "-64")["tag"] == "3.13.0-64"
+    assert select_package([index], "3.13-32", "-64")["tag"] == "3.13.0-32"
     assert select_package([index], "3.13", "-32")["tag"] == "3.13.0-32"
+    assert select_package([index], "3.13-64", "-32")["tag"] == "3.13.0-64"

--- a/tests/test_installs.py
+++ b/tests/test_installs.py
@@ -6,10 +6,10 @@ from manage import installs
 
 
 def make_install(tag, **kwargs):
-    run_for = [
-        {"tag": tag, "target": kwargs.get("target", "python.exe")},
-        {"tag": tag, "target": kwargs.get("targetw", "pythonw.exe"), "windowed": 1},
-    ]
+    run_for = []
+    for t in kwargs.get("run_for", [tag]):
+        run_for.append({"tag": t, "target": kwargs.get("target", "python.exe")})
+        run_for.append({"tag": t, "target": kwargs.get("targetw", "pythonw.exe"), "windowed": 1})
 
     return {
         "company": kwargs.get("company", "PythonCore"),
@@ -40,9 +40,9 @@ def fake_get_installs(install_dir):
 
 def fake_get_installs2(install_dir):
     yield make_install("1.0-32", sort_version="1.0")
-    yield make_install("3.0a1-32", sort_version="3.0a1")
-    yield make_install("3.0a1-64", sort_version="3.0a1")
-    yield make_install("3.0a1-arm64", sort_version="3.0a1")
+    yield make_install("3.0a1-32", sort_version="3.0a1", run_for=["3-32", "3.0-32", "3.0a1-32"])
+    yield make_install("3.0a1-64", sort_version="3.0a1", run_for=["3-64", "3.0-64", "3.0a1-64"])
+    yield make_install("3.0a1-arm64", sort_version="3.0a1", run_for=["3-arm64", "3.0-arm64", "3.0a1-arm64"])
 
 
 def fake_get_unmanaged_installs():
@@ -159,6 +159,15 @@ def test_get_install_to_run_with_default_platform_prerelease(patched_installs2):
     assert i["id"] == "PythonCore-1.0-32"
     i = installs.get_install_to_run("<none>", None, None, default_platform="-arm64")
     assert i["id"] == "PythonCore-1.0-32"
+
+
+def test_get_install_to_run_with_platform_prerelease(patched_installs2):
+    i = installs.get_install_to_run("<none>", None, "3", default_platform="-32")
+    assert i["id"] == "PythonCore-3.0a1-32"
+    i = installs.get_install_to_run("<none>", None, "3-32", default_platform="-64")
+    assert i["id"] == "PythonCore-3.0a1-32"
+    i = installs.get_install_to_run("<none>", None, "3-32", default_platform="-arm64")
+    assert i["id"] == "PythonCore-3.0a1-32"
 
 
 def test_get_install_to_run_with_range(patched_installs):


### PR DESCRIPTION
Previously, if all matching runtimes were prereleases, the platform specifier would essentially be ignored. Now, when all matches are prereleases, we are okay with all matches after applying the platform filter being prereleases.