### PR TITLE
Fix internal error for ``py list --format url``

### DIFF
--- a/src/manage/list_command.py
+++ b/src/manage/list_command.py
@@ -189,7 +189,10 @@ def format_bare_prefix(cmd, installs):
 
 def format_bare_url(cmd, installs):
     for i in installs:
-        print(i["url"])
+        try:
+            print(i["url"])
+        except KeyError:
+            pass
 
 
 def format_legacy(cmd, installs, paths=False):


### PR DESCRIPTION
```ps1con
PS> py list -f url -vv
...
[ERROR] INTERNAL ERROR: KeyError: 'url'
# TRACEBACK:
Traceback (most recent call last):
  File "manage\__init__.py", line 50, in main
  File "manage\commands.py", line 665, in execute
  File "manage\list_command.py", line 300, in execute
  File "manage\list_command.py", line 192, in format_bare_url
KeyError: 'url'
```

A