### PR TITLE
Remove legacy formatters from ``py list`` error output

### DIFF
--- a/src/manage/list_command.py
+++ b/src/manage/list_command.py
@@ -253,7 +253,7 @@ def execute(cmd):
     except LookupError:
         formatters = FORMATTERS.keys() - {"legacy", "legacy-paths"}
         expect = ", ".join(sorted(formatters))
-        raise ArgumentError(f"'{cmd.format}' is not a valid format; expect one of: {expect}") from None
+        raise ArgumentError(f"'{cmd.format}' is not a valid format; expected one of: {expect}") from None
 
     from .tagutils import tag_or_range, install_matches_any
     tags = []

--- a/src/manage/list_command.py
+++ b/src/manage/list_command.py
@@ -251,7 +251,8 @@ def execute(cmd):
         LOGGER.debug("Get formatter %s", cmd.format)
         formatter = FORMATTERS[cmd.format]
     except LookupError:
-        expect = ", ".join(sorted(FORMATTERS))
+        formatters = FORMATTERS.keys() - {"legacy", "legacy-paths"}
+        expect = ", ".join(sorted(formatters))
         raise ArgumentError(f"'{cmd.format}' is not a valid format; expect one of: {expect}") from None
 
     from .tagutils import tag_or_range, install_matches_any


### PR DESCRIPTION
Currently:

```ps1con
PS> py list --format spam
...

[ERROR] 'spam' is not a valid format; expect one of: csv, exe, id, json, jsonl, legacy, legacy-paths, prefix, table, url
```

However, the help output only lists `--format=<table,json,jsonl,id,exe,prefix>`. This PR removes the two 'legacy' entries, but keeps CSV and URL, as it might be useful to hint that these exist.

A