### PR TITLE
Update PyManager to use 3.14.0b1 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,12 +43,9 @@ jobs:
     - name: Set up Python 3.14.0b1
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
-        dir -r
-        $py = Get-Item python\tools\python.exe
-        $old = Get-Content $env:GITHUB_PATH
-        Write-Host "Adding $($py.Parent) to GITHUB_PATH (${env:GITHUB_PATH})"
-        "$($py.Parent)" | Out-File $env:GITHUB_PATH -Encoding UTF8
-        $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
+        $py = Get-Item python\tools
+        Write-Host "Adding $py to GITHUB_PATH (${env:GITHUB_PATH})"
+        $py" | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
         Write-Host "PATH entries:"
         Write-Host (Get-Content $env:GITHUB_PATH)
       working-directory: ${{ runner.temp }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python 3.14.0b1
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
-        $py = Get-Item .\python*\tools\python.exe
+        $py = Get-ChildItem -Recurse .\*\tools\python.exe | select -Last 1
         $old = Get-Content $env:GITHUB_PATH
         Write-Host "Adding $($py.Parent) to GITHUB_PATH"
         "$($py.Parent)" | Out-File $env:GITHUB_PATH -Encoding UTF8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,21 @@ jobs:
         }
       shell: powershell
 
-    - name: Set up Python 3.14
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.14-dev
+    #- name: Set up Python 3.14
+    #  uses: actions/setup-python@v5
+    #  with:
+    #    python-version: 3.14-dev
+
+    # We move faster than GitHub's Python runtimes, so use NuGet instead
+    # One day we can use ourselves to download Python, but not yet...
+    - name: Set up NuGet
+      uses: nuget/setup-nuget@v2.0.1
+
+    - name: Set up Python 3.14.0b1
+      run: |
+        nuget install python -Version 3.14.0-b1 -x -o .
+        (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
+      working-directory: ${{ runner.temp }}
 
     - name: Install build dependencies
       run: python -m pip install "pymsbuild>=1.2.0b1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,13 @@ jobs:
         $old = Get-Content $env:GITHUB_PATH
         (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8
         $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
-        gc $env:GITHUB_PATH
+        Write-Host "PATH entries:"
+        Write-Host (gc $env:GITHUB_PATH)
       working-directory: ${{ runner.temp }}
 
     - name: Check Python version
       run: >
-        python -c "
-        import sys;
+        python -c "import sys;
         print(sys.version);
         print(sys.executable);
         sys.exit(0 if sys.version_info[:3] == (3, 14, 0) else 1)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,13 @@ jobs:
     - name: Set up Python 3.14.0b1
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
-        (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
+        $old = Get-Content $env:GITHUB_PATH
+        (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8
+        $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
       working-directory: ${{ runner.temp }}
+
+    - name: Check Python version
+      run: python -c "import sys; sys.exit(0 if sys.version_info[:3] == (3, 14, 0) else 1)"
 
     - name: Install build dependencies
       run: python -m pip install "pymsbuild>=1.2.0b1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,18 +44,16 @@ jobs:
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
         $py = Get-Item python\tools
-        Write-Host "Adding $py to GITHUB_PATH (${env:GITHUB_PATH})"
+        Write-Host "Adding $py to PATH"
         "$py" | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
-        Write-Host "PATH entries:"
-        Write-Host (Get-Content $env:GITHUB_PATH)
       working-directory: ${{ runner.temp }}
 
-    - name: Check Python version
+    - name: Check Python version is 3.14.0b1
       run: >
         python -c "import sys;
         print(sys.version);
         print(sys.executable);
-        sys.exit(0 if sys.version_info[:3] == (3, 14, 0) else 1)"
+        sys.exit(0 if sys.version_info[:5] == (3, 14, 0, 'beta', 1) else 1)"
 
     - name: Install build dependencies
       run: python -m pip install "pymsbuild>=1.2.0b1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Set up Python 3.14.0b1
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
+        dir -r
         $py = Get-ChildItem -Recurse .\*\tools\python.exe | select -Last 1
         $old = Get-Content $env:GITHUB_PATH
         Write-Host "Adding $($py.Parent) to GITHUB_PATH"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,13 @@ jobs:
     - name: Set up Python 3.14.0b1
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
+        $py = Get-Item .\python*\tools\python.exe
         $old = Get-Content $env:GITHUB_PATH
-        (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8
+        Write-Host "Adding $($py.Parent) to GITHUB_PATH"
+        "$($py.Parent)" | Out-File $env:GITHUB_PATH -Encoding UTF8
         $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
         Write-Host "PATH entries:"
-        Write-Host (gc $env:GITHUB_PATH)
+        Write-Host (Get-Content $env:GITHUB_PATH)
       working-directory: ${{ runner.temp }}
 
     - name: Check Python version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,9 @@ jobs:
       run: |
         nuget install python -Version 3.14.0-b1 -x -o .
         dir -r
-        $py = Get-ChildItem -Recurse .\*\tools\python.exe | select -Last 1
+        $py = Get-Item python\tools\python.exe
         $old = Get-Content $env:GITHUB_PATH
-        Write-Host "Adding $($py.Parent) to GITHUB_PATH"
+        Write-Host "Adding $($py.Parent) to GITHUB_PATH (${env:GITHUB_PATH})"
         "$($py.Parent)" | Out-File $env:GITHUB_PATH -Encoding UTF8
         $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
         Write-Host "PATH entries:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,16 @@ jobs:
         $old = Get-Content $env:GITHUB_PATH
         (gi .\python*\tools\python.exe).Parent | Out-File $env:GITHUB_PATH -Encoding UTF8
         $old | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
+        gc $env:GITHUB_PATH
       working-directory: ${{ runner.temp }}
 
     - name: Check Python version
-      run: python -c "import sys; sys.exit(0 if sys.version_info[:3] == (3, 14, 0) else 1)"
+      run: >
+        python -c "
+        import sys;
+        print(sys.version);
+        print(sys.executable);
+        sys.exit(0 if sys.version_info[:3] == (3, 14, 0) else 1)"
 
     - name: Install build dependencies
       run: python -m pip install "pymsbuild>=1.2.0b1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         nuget install python -Version 3.14.0-b1 -x -o .
         $py = Get-Item python\tools
         Write-Host "Adding $py to GITHUB_PATH (${env:GITHUB_PATH})"
-        $py" | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
+        "$py" | Out-File $env:GITHUB_PATH -Encoding UTF8 -Append
         Write-Host "PATH entries:"
         Write-Host (Get-Content $env:GITHUB_PATH)
       working-directory: ${{ runner.temp }}

--- a/_msbuild.py
+++ b/_msbuild.py
@@ -4,7 +4,7 @@ from pymsbuild.dllpack import *
 
 
 DLL_NAME = "python314"
-EMBED_URL = "https://www.python.org/ftp/python/3.14.0/python-3.14.0a7-embed-amd64.zip"
+EMBED_URL = "https://www.python.org/ftp/python/3.14.0/python-3.14.0b1-embed-amd64.zip"
 
 def can_embed(tag):
     """Return False if tag doesn't match DLL_NAME and EMBED_URL.


### PR DESCRIPTION
This is expected to fail CI right now, but once we've released b1 then it can rerun and merge, after which we should be able to make a release that bundles 3.14.0b1.