### PR TITLE
Adopt pymsbuild-msix for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         sys.exit(0 if sys.version_info[:5] == (3, 14, 0, 'beta', 1) else 1)"
 
     - name: Install build dependencies
-      run: python -m pip install "pymsbuild>=1.2.0b1"
+      run: python -m pip install "pymsbuild>=1.2.2b1" "pymsbuild-msix>=0.1.0a1"
 
     - name: 'Install test runner'
       run: python -m pip install pytest pytest-cov

--- a/_msbuild.py
+++ b/_msbuild.py
@@ -1,6 +1,7 @@
 import os
 from pymsbuild import *
 from pymsbuild.dllpack import *
+from pymsbuild_msix import AppxManifest, AppInstaller, ResourcesXml
 
 
 DLL_NAME = "python314"
@@ -15,7 +16,7 @@ def can_embed(tag):
 
 METADATA = {
     "Metadata-Version": "2.2",
-    "Name": "manage",
+    "Name": "python-manager",
     "Version": "0.1a0",
     "Author": "Python Software Foundation",
     "Author-email": "steve.dower@python.org",
@@ -179,8 +180,8 @@ def pyshellext(ext='.exe', **props):
 PACKAGE = Package('python-manager',
     PyprojectTomlFile('pyproject.toml'),
     # MSIX manifest
-    File('src/pymanager/appxmanifest.xml'),
-    File('src/pymanager/pymanager.appinstaller'),
+    AppxManifest('src/pymanager/appxmanifest.xml'),
+    AppInstaller('src/pymanager/pymanager.appinstaller'),
     Package(
         'MSIX.AppInstaller.Data',
         File('src/pymanager/MSIXAppInstallerData.xml'),
@@ -208,6 +209,7 @@ PACKAGE = Package('python-manager',
     ),
 
     # Directory for MSIX resources
+    ResourcesXml('src/pymanager/resources.xml'),
     Package(
         '_resources',
         File('src/pymanager/_resources/*.png'),

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -93,7 +93,7 @@ stages:
       workingDirectory: $(Build.BinariesDirectory)
 
     - powershell: |
-        python -m pip install "pymsbuild>=1.2.0b1"
+        python -m pip install "pymsbuild>=1.2.2b1" "pymsbuild-msix>=0.1.0a1"
       displayName: 'Install build dependencies'
 
     - ${{ if eq(parameters.PreTest, 'true') }}:

--- a/make-msi.py
+++ b/make-msi.py
@@ -12,13 +12,13 @@ MSBUILD_CMD = get_msbuild()
 DIRS = get_dirs()
 BUILD = DIRS["build"]
 TEMP = DIRS["temp"]
-LAYOUT = DIRS["out"]
+LAYOUT = DIRS["out"] / "python-manager"
 SRC = DIRS["src"]
 DIST = DIRS["dist"]
 
 # Calculate output names (must be after building)
-NAME = get_output_name(DIRS)
-VERSION = get_msix_version(DIRS)
+NAME = get_output_name(DIRS["out"])
+VERSION = get_msix_version(LAYOUT / "appxmanifest.xml")
 
 # Package into MSI
 pydllname = [p.stem for p in (LAYOUT / "runtime").glob("python*.dll")][0]


### PR DESCRIPTION
Mostly just a proof of concept for upstreaming the MSIX build into a pymsbuild extension. No hurry to merge this, and probably not recommended while pymsbuild-msix is still in its earliest stages.