### PR TITLE
Separate default install tag from default launch tag.

### DIFF
--- a/src/manage/commands.py
+++ b/src/manage/commands.py
@@ -22,7 +22,7 @@ LOGGER = logging.LOGGER
 # or check out the docs for administrative controls:
 #    https://docs.python.org/using/windows
 DEFAULT_SOURCE_URL = "https://www.python.org/ftp/python/index-windows.json"
-DEFAULT_TAG = "3.14"
+DEFAULT_TAG = "3"
 
 
 # TODO: Remove the /dev/ for stable release
@@ -253,6 +253,7 @@ CONFIG_SCHEMA = {
         "fallback_source": (str, None, "env", "path", "uri"),
         "enable_shortcut_kinds": (str, config_split_append),
         "disable_shortcut_kinds": (str, config_split_append),
+        "default_install_tag": (str, None),
     },
 
     "first_run": {
@@ -792,6 +793,7 @@ Downloads new Python runtimes and sets up shortcuts and other registration.
     from_script = None
     enable_shortcut_kinds = None
     disable_shortcut_kinds = None
+    default_install_tag = DEFAULT_TAG
 
     def __init__(self, args, root=None):
         super().__init__(args, root)

--- a/src/manage/commands.py
+++ b/src/manage/commands.py
@@ -793,13 +793,15 @@ Downloads new Python runtimes and sets up shortcuts and other registration.
     from_script = None
     enable_shortcut_kinds = None
     disable_shortcut_kinds = None
-    default_install_tag = DEFAULT_TAG
+    default_install_tag = None
 
     def __init__(self, args, root=None):
         super().__init__(args, root)
 
         if not self.source:
             self.source = DEFAULT_SOURCE_URL
+        if not self.default_install_tag:
+            self.default_install_tag = self.default_tag
         if "://" not in str(self.source):
             try:
                 self.source = Path(self.source).absolute().as_uri()

--- a/src/manage/config.py
+++ b/src/manage/config.py
@@ -208,6 +208,8 @@ def resolve_config(cfg, source, relative_to, key_so_far="", schema=None, error_u
 
 def merge_config(into_cfg, from_cfg, schema, *, source="<unknown>", overwrite=False):
     for k, v in from_cfg.items():
+        if k.startswith("#"):
+            continue
         try:
             into = into_cfg[k]
         except LookupError:

--- a/src/manage/install_command.py
+++ b/src/manage/install_command.py
@@ -604,8 +604,8 @@ def execute(cmd):
     if not cmd.by_id:
         for arg in cmd.args:
             if arg.casefold() == "default".casefold():
-                LOGGER.debug("Replacing 'default' with '%s'", cmd.default_tag)
-                cmd.tags.append(tag_or_range(cmd.default_tag))
+                LOGGER.debug("Replacing 'default' with '%s'", cmd.default_install_tag)
+                cmd.tags.append(tag_or_range(cmd.default_install_tag))
             else:
                 try:
                     cmd.tags.append(tag_or_range(arg))
@@ -613,7 +613,7 @@ def execute(cmd):
                     LOGGER.warn("%s", ex)
 
         if not cmd.tags and cmd.automatic:
-            cmd.tags = [tag_or_range(cmd.default_tag)]
+            cmd.tags = [tag_or_range(cmd.default_install_tag)]
     else:
         if cmd.from_script:
             raise ArgumentError("Cannot use --by-id and --from-script together")
@@ -629,9 +629,9 @@ def execute(cmd):
             try:
                 tag = cmd.tags[0]
             except IndexError:
-                if cmd.default_tag:
-                    LOGGER.debug("No tags provided, installing default tag %s", cmd.default_tag)
-                    tag = cmd.default_tag
+                if cmd.default_install_tag:
+                    LOGGER.debug("No tags provided, installing default tag %s", cmd.default_install_tag)
+                    tag = cmd.default_install_tag
                 else:
                     LOGGER.debug("No tags provided, installing first runtime in feed")
                     tag = None
@@ -671,7 +671,7 @@ def execute(cmd):
             if spec:
                 cmd.tags.append(tag_or_range(spec))
             else:
-                cmd.tags.append(tag_or_range(cmd.default_tag))
+                cmd.tags.append(tag_or_range(cmd.default_install_tag))
 
         if cmd.virtual_env:
             LOGGER.debug("Clearing virtual_env setting to avoid conflicts during install.")

--- a/src/pymanager.json
+++ b/src/pymanager.json
@@ -1,7 +1,10 @@
 {
     "install": {
         "source": "%PYTHON_MANAGER_SOURCE_URL%",
-        "fallback_source": "./bundled/fallback-index.json"
+        "fallback_source": "./bundled/fallback-index.json",
+
+        "#": "Install 3.14 (prerelease) by default during prerelease PyManager",
+        "default_install_tag": "3-dev"
     },
     "list": {
         "format": "%PYTHON_MANAGER_LIST_FORMAT%"


### PR DESCRIPTION
This 'fixes' issues people have where they want prerelease installer but not prerelease Python.
At 3.14's release, we'll remove the default config setting that installs 3-dev.
Fixes #122