### PR TITLE
Fix signed build test issues

### DIFF
--- a/ci/release.yml
+++ b/ci/release.yml
@@ -145,6 +145,9 @@ stages:
             "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]$servicePrincipalId" 
             "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$idToken"
             "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]$tenantId"
+            $tokenPath = "$env:AGENT_TEMPDIRECTORY\federated-token.jwt"
+            Set-Content -Path $tokenPath -Value $env:idToken
+            Write-Host "##vso[task.setvariable variable=AZURE_FEDERATED_TOKEN_FILE]$tokenPath"
           addSpnToEnvironment: true
 
     - powershell: |

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -27,6 +27,10 @@ parameters:
   displayName: "Post test"
   type: boolean
   default: true
+- name: PostTestWithHangs
+  displayName: "Post tests that may hang"
+  type: boolean
+  default: true
 - name: OverrideRef
   displayName: "Force version (else uses tag)"
   type: string
@@ -237,47 +241,49 @@ stages:
             TEST_MSIX: $(TEST_MSIX_DIR)
 
       - powershell: |
-          gcm pymanager
-          gcm pywmanager
-          # These are likely present due to the machine configuration,
+          # Some of these are likely present due to the machine configuration,
           # but we'll check for them anyway.
-          gcm py
-          gcm python
-          gcm pyw
-          gcm pythonw
+          gcm pymanager, pywmanager, py, python, pyw, pythonw | Format-Table -AutoSize
         displayName: 'Ensure global commands are present'
 
-      - powershell: |
-          pymanager help
-        displayName: 'Show help output'
+      - ${{ if eq(parameters.PostTestWithHangs, 'true') }}:
+        - powershell: |
+            pymanager help
+          displayName: 'Show help output'
+          timeoutInMinutes: 1
 
       - powershell: |
           pymanager install -vv default
         displayName: 'Install default runtime'
+        timeoutInMinutes: 5
         env:
           PYMANAGER_DEBUG: true
 
       - powershell: |
           pymanager list
         displayName: 'List installed runtimes'
+        timeoutInMinutes: 1
         env:
           PYMANAGER_DEBUG: true
 
       - powershell: |
           pymanager --list-paths
         displayName: 'List installed runtimes (legacy)'
+        timeoutInMinutes: 1
         env:
           PYMANAGER_DEBUG: true
 
       - powershell: |
           pymanager exec -m site
         displayName: 'Launch default runtime'
+        timeoutInMinutes: 1
         env:
           PYMANAGER_DEBUG: true
 
       - powershell: |
           pymanager uninstall -y default
         displayName: 'Uninstall runtime'
+        timeoutInMinutes: 3
         env:
           PYMANAGER_DEBUG: true
 
@@ -291,6 +297,7 @@ stages:
           pymanager install --configure -y
           if ($?) { pymanager list }
         displayName: 'Emulate first launch'
+        timeoutInMinutes: 5
         env:
           PYTHON_MANAGER_INCLUDE_UNMANAGED: false
           PYTHON_MANAGER_CONFIG: .\test-config.json
@@ -302,6 +309,7 @@ stages:
           pymanager list --source .\bundle
           pymanager install --source .\bundle 3 3-32 3-64 3-arm64
         displayName: 'Offline bundle download and install'
+        timeoutInMinutes: 5
         env:
           PYMANAGER_DEBUG: true
 

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -153,11 +153,11 @@ stages:
           scriptLocation: inlineScript
           inlineScript: |
             dir -r *.exe, *.pyd | %{
-            sign code trusted-signing "$_"
-            -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
-            -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
-            -d "PyManager $(Build.BuildNumber)"
-            -fl $env:SIGNLIST1
+              sign code trusted-signing "$_" `
+                -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256 `
+                -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)" `
+                -d "PyManager $(Build.BuildNumber)" `
+                -fl $env:SIGNLIST1
             }
           workingDirectory: $(LAYOUT_DIR)
 
@@ -189,11 +189,11 @@ stages:
           scriptLocation: inlineScript
           inlineScript: |
             dir *.msix, *.msi | %{
-            sign code trusted-signing "$_"
-            -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
-            -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
-            -d "PyManager $(Build.BuildNumber)"
-            -fl $env:SIGNLIST2
+              sign code trusted-signing "$_" `
+                -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256 `
+                -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)" `
+                -d "PyManager $(Build.BuildNumber)" `
+                -fl $env:SIGNLIST2
             }
           workingDirectory: $(DIST_DIR)
 

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -68,10 +68,10 @@ stages:
       vmImage: 'windows-latest'
 
     variables:
-    - ${{ if eq(parameters.Sign, 'true') }}:
-      - group: CPythonSign
     - ${{ if eq(parameters.TestSign, 'true') }}:
       - group: CPythonTestSign
+    - ${{ elseif eq(parameters.Sign, 'true') }}:
+      - group: CPythonSign
     - ${{ if eq(parameters.Publish, 'true') }}:
       - group: PythonOrgPublish
 
@@ -145,20 +145,21 @@ stages:
           PYMANAGER_APPX_PUBLISHER: $(TrustedSigningCertificateSubject)
 
     - ${{ if or(eq(parameters.Sign, 'true'), eq(parameters.TestSign, 'true')) }}:
-      - powershell: >
-          dir -r *.exe, *.pyd | %{
-          sign code trusted-signing "$_"
-          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
-          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
-          -d "PyManager $(Build.BuildNumber)"
-          -fl $env:SIGNLIST1
-          }
+      - task: AzureCLI@2
         displayName: 'Sign binaries'
-        workingDirectory: $(LAYOUT_DIR)
-        env:
-          AZURE_CLIENT_ID: $(TrustedSigningClientId)
-          AZURE_CLIENT_SECRET: $(TrustedSigningSecret)
-          AZURE_TENANT_ID: $(TrustedSigningTenantId)
+        inputs:
+          azureSubscription: 'Python Signing'
+          scriptType: ps
+          scriptLocation: inlineScript
+          inlineScript: |
+            dir -r *.exe, *.pyd | %{
+            sign code trusted-signing "$_"
+            -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
+            -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
+            -d "PyManager $(Build.BuildNumber)"
+            -fl $env:SIGNLIST1
+            }
+          workingDirectory: $(LAYOUT_DIR)
 
     - powershell: |
         python make-msix.py
@@ -180,49 +181,35 @@ stages:
           PYMANAGER_APPX_PUBLISHER: $(TrustedSigningCertificateSubject)
 
     - ${{ if or(eq(parameters.Sign, 'true'), eq(parameters.TestSign, 'true')) }}:
-      - powershell: >
-          dir *.msix | %{
-          sign code trusted-signing "$_"
-          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
-          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
-          -d "PyManager $(Build.BuildNumber)"
-          -fl $env:SIGNLIST2
-          }
-        displayName: 'Sign MSIX package'
-        workingDirectory: $(DIST_DIR)
-        env:
-          AZURE_CLIENT_ID: $(TrustedSigningClientId)
-          AZURE_CLIENT_SECRET: $(TrustedSigningSecret)
-          AZURE_TENANT_ID: $(TrustedSigningTenantId)
+      - task: AzureCLI@2
+        displayName: 'Sign packages'
+        inputs:
+          azureSubscription: 'Python Signing'
+          scriptType: ps
+          scriptLocation: inlineScript
+          inlineScript: |
+            dir *.msix, *.msi | %{
+            sign code trusted-signing "$_"
+            -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
+            -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
+            -d "PyManager $(Build.BuildNumber)"
+            -fl $env:SIGNLIST2
+            }
+          workingDirectory: $(DIST_DIR)
 
-      - powershell: >
-          dir *.msi | %{
-          sign code trusted-signing "$_"
-          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
-          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
-          -d "PyManager $(Build.BuildNumber)"
-          -fl $env:SIGNLIST3
-          }
-        displayName: 'Sign MSI package'
-        workingDirectory: $(DIST_DIR)
-        env:
-          AZURE_CLIENT_ID: $(TrustedSigningClientId)
-          AZURE_CLIENT_SECRET: $(TrustedSigningSecret)
-          AZURE_TENANT_ID: $(TrustedSigningTenantId)
-
-    - ${{ if eq(parameters.Sign, 'true') }}:
-      - powershell: Write-Host "##vso[build.addbuildtag]signed"
-        displayName: 'Add signed build tag'
-    - ${{ elseif eq(parameters.TestSign, 'true') }}:
+    - ${{ if eq(parameters.TestSign, 'true') }}:
       - powershell: Write-Host "##vso[build.addbuildtag]test-signed"
         displayName: 'Add test-signed build tag'
+    - ${{ elseif eq(parameters.Sign, 'true') }}:
+      - powershell: Write-Host "##vso[build.addbuildtag]signed"
+        displayName: 'Add signed build tag'
 
     - publish: $(DIST_DIR)
       artifact: dist
       displayName: Publish distribution artifacts
 
     - ${{ if eq(parameters.PostTest, 'true') }}:
-      - ${{ if eq(parameters.Sign, 'true') }}:
+      - ${{ if and(ne(parameters.TestSign, 'true'), eq(parameters.Sign, 'true')) }}:
         - powershell: |
             $msix = dir "$(DIST_DIR)\*.msix" | ?{ -not ($_.BaseName -match '.+-store') } | select -first 1
             Add-AppxPackage $msix

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -65,7 +65,7 @@ stages:
   - job: Build
 
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
 
     variables:
     - ${{ if eq(parameters.TestSign, 'true') }}:

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -136,7 +136,7 @@ stages:
         workingDirectory: $(Build.BinariesDirectory)
 
       - task: AzureCLI@2
-        displayName: 'Azure CLI'
+        displayName: 'Azure Login (1/2)'
         inputs:
           azureSubscription: 'Python Signing'
           scriptType: 'ps'
@@ -145,10 +145,15 @@ stages:
             "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]$servicePrincipalId" 
             "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$idToken"
             "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]$tenantId"
-            $tokenPath = "$env:AGENT_TEMPDIRECTORY\federated-token.jwt"
-            Set-Content -Path $tokenPath -Value $env:idToken
-            Write-Host "##vso[task.setvariable variable=AZURE_FEDERATED_TOKEN_FILE]$tokenPath"
           addSpnToEnvironment: true
+
+      - powershell: >
+          az login --service-principal
+          -u $(AZURE_CLIENT_ID)
+          --tenant $(AZURE_TENANT_ID)
+          --allow-no-subscriptions
+          --federated-token $(AZURE_ID_TOKEN)
+        displayName: 'Azure Login (2/2)'
 
     - powershell: |
         python make.py
@@ -170,10 +175,6 @@ stages:
           }
         displayName: 'Sign binaries'
         workingDirectory: $(LAYOUT_DIR)
-        env:
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
 
     - powershell: |
         python make-msix.py
@@ -205,10 +206,6 @@ stages:
           }
         displayName: 'Sign MSIX package'
         workingDirectory: $(DIST_DIR)
-        env:
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
 
       - powershell: >
           dir *.msi | %{
@@ -220,10 +217,6 @@ stages:
           }
         displayName: 'Sign MSI package'
         workingDirectory: $(DIST_DIR)
-        env:
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
 
     - ${{ if eq(parameters.TestSign, 'true') }}:
       - powershell: Write-Host "##vso[build.addbuildtag]test-signed"

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -142,9 +142,9 @@ stages:
           scriptType: 'ps'
           scriptLocation: 'inlineScript'
           inlineScript: |
-            "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]$servicePrincipalId" 
-            "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$idToken"
-            "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]$tenantId"
+            "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]${env:servicePrincipalId}" 
+            "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]${env:idToken}"
+            "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]${env:tenantId}"
           addSpnToEnvironment: true
 
       - powershell: >

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -135,6 +135,18 @@ stages:
         displayName: 'Install signing tool and generate files'
         workingDirectory: $(Build.BinariesDirectory)
 
+      - task: AzureCLI@2
+        displayName: 'Azure CLI'
+        inputs:
+          azureSubscription: 'Python Signing'
+          scriptType: 'ps'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            "##vso[task.setvariable variable=AZURE_CLIENT_ID;issecret=true]$servicePrincipalId" 
+            "##vso[task.setvariable variable=AZURE_ID_TOKEN;issecret=true]$idToken"
+            "##vso[task.setvariable variable=AZURE_TENANT_ID;issecret=true]$tenantId"
+          addSpnToEnvironment: true
+
     - powershell: |
         python make.py
       displayName: 'Build package'
@@ -145,21 +157,20 @@ stages:
           PYMANAGER_APPX_PUBLISHER: $(TrustedSigningCertificateSubject)
 
     - ${{ if or(eq(parameters.Sign, 'true'), eq(parameters.TestSign, 'true')) }}:
-      - task: AzureCLI@2
+      - powershell: >
+          dir -r *.exe, *.pyd | %{
+          sign code trusted-signing "$_"
+          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
+          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
+          -d "PyManager $(Build.BuildNumber)"
+          -fl $env:SIGNLIST1
+          }
         displayName: 'Sign binaries'
-        inputs:
-          azureSubscription: 'Python Signing'
-          scriptType: ps
-          scriptLocation: inlineScript
-          inlineScript: |
-            dir -r *.exe, *.pyd | %{
-              sign code trusted-signing "$_" `
-                -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256 `
-                -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)" `
-                -d "PyManager $(Build.BuildNumber)" `
-                -fl $env:SIGNLIST1
-            }
-          workingDirectory: $(LAYOUT_DIR)
+        workingDirectory: $(LAYOUT_DIR)
+        env:
+          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
 
     - powershell: |
         python make-msix.py
@@ -181,21 +192,35 @@ stages:
           PYMANAGER_APPX_PUBLISHER: $(TrustedSigningCertificateSubject)
 
     - ${{ if or(eq(parameters.Sign, 'true'), eq(parameters.TestSign, 'true')) }}:
-      - task: AzureCLI@2
-        displayName: 'Sign packages'
-        inputs:
-          azureSubscription: 'Python Signing'
-          scriptType: ps
-          scriptLocation: inlineScript
-          inlineScript: |
-            dir *.msix, *.msi | %{
-              sign code trusted-signing "$_" `
-                -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256 `
-                -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)" `
-                -d "PyManager $(Build.BuildNumber)" `
-                -fl $env:SIGNLIST2
-            }
-          workingDirectory: $(DIST_DIR)
+      - powershell: >
+          dir *.msix | %{
+          sign code trusted-signing "$_"
+          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
+          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
+          -d "PyManager $(Build.BuildNumber)"
+          -fl $env:SIGNLIST2
+          }
+        displayName: 'Sign MSIX package'
+        workingDirectory: $(DIST_DIR)
+        env:
+          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+
+      - powershell: >
+          dir *.msi | %{
+          sign code trusted-signing "$_"
+          -fd sha256 -t http://timestamp.acs.microsoft.com -td sha256
+          -tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)"
+          -d "PyManager $(Build.BuildNumber)"
+          -fl $env:SIGNLIST3
+          }
+        displayName: 'Sign MSI package'
+        workingDirectory: $(DIST_DIR)
+        env:
+          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
 
     - ${{ if eq(parameters.TestSign, 'true') }}:
       - powershell: Write-Host "##vso[build.addbuildtag]test-signed"

--- a/ci/release.yml
+++ b/ci/release.yml
@@ -27,10 +27,6 @@ parameters:
   displayName: "Post test"
   type: boolean
   default: true
-- name: PostTestWithHangs
-  displayName: "Post tests that may hang"
-  type: boolean
-  default: true
 - name: OverrideRef
   displayName: "Force version (else uses tag)"
   type: string
@@ -65,7 +61,7 @@ stages:
   - job: Build
 
     pool:
-      vmImage: 'windows-2022'
+      vmImage: 'windows-latest'
 
     variables:
     - ${{ if eq(parameters.TestSign, 'true') }}:
@@ -234,7 +230,6 @@ stages:
         - powershell: |
             $msix = dir "$(DIST_DIR)\*.msix" | ?{ -not ($_.BaseName -match '.+-store') } | select -first 1
             Add-AppxPackage $msix
-            Get-AppxPackage PythonSoftwareFoundation.PythonManager
           displayName: 'Install signed MSIX'
 
       - ${{ else }}:
@@ -243,10 +238,18 @@ stages:
             cp $msix "${msix}.zip"
             Expand-Archive "${msix}.zip" (mkdir -Force $env:TEST_MSIX)
             Add-AppxPackage -Register "${env:TEST_MSIX}\appxmanifest.xml"
-            Get-AppxPackage PythonSoftwareFoundation.PythonManager
           displayName: 'Register unsigned MSIX'
           env:
             TEST_MSIX: $(TEST_MSIX_DIR)
+
+      - powershell: |
+          $p = Get-AppxPackage PythonSoftwareFoundation.PythonManager
+          $p
+          Set-AppxPackageAutoUpdateSettings $p.PackageFamilyName -CheckOnLaunch $false
+          Set-AppxPackageAutoUpdateSettings $p.PackageFamilyName -ShowPrompt $false
+          Set-AppxPackageAutoUpdateSettings $p.PackageFamilyName -PauseUpdates -HoursToPause 1
+          Get-AppxPackageAutoUpdateSettings $p.PackageFamilyName
+        displayName: 'Update MSIX settings'
 
       - powershell: |
           # Some of these are likely present due to the machine configuration,
@@ -254,11 +257,10 @@ stages:
           gcm pymanager, pywmanager, py, python, pyw, pythonw | Format-Table -AutoSize
         displayName: 'Ensure global commands are present'
 
-      - ${{ if eq(parameters.PostTestWithHangs, 'true') }}:
-        - powershell: |
-            pymanager help
-          displayName: 'Show help output'
-          timeoutInMinutes: 1
+      - powershell: |
+          pymanager help
+        displayName: 'Show help output'
+        timeoutInMinutes: 1
 
       - powershell: |
           pymanager install -vv default


### PR DESCRIPTION
* disables automatic updating while running tests
* adds timeouts for test stages (in case they block endlessly)
* ensures that test signing overrules real signing
* removes use of stored secret tokens