### PR TITLE
Fix `os.path.commonprefix` deprecation

### DIFF
--- a/src/manage/fsutils.py
+++ b/src/manage/fsutils.py
@@ -153,7 +153,10 @@ def rmtree(path, after_5s_warning=None, remove_ext_first=()):
             _rmdir(d, on_fail=to_warn.append, on_isfile=to_unlink)
 
     if to_warn:
-        f = os.path.commonprefix(to_warn)
+        try:
+            f = os.path.commonpath(to_warn)
+        except ValueError:
+            f = None
         if f:
             LOGGER.warn("Failed to remove %s", f)
         else:


### PR DESCRIPTION
See:

* https://sethmlarson.dev/deprecate-confusing-apis-like-os-path-commonprefix
* [python/cpython#74453](https://github.com/python/cpython/issues/74453) & [python/cpython#144436](https://github.com/python/cpython/pull/144436)
* https://docs.python.org/3/library/os.path.html#os.path.commonprefix
