### PR TITLE
Fix Invoke-WebRequest IDictionary cast error

### DIFF
--- a/src/manage/pathutils.py
+++ b/src/manage/pathutils.py
@@ -11,6 +11,17 @@ def _eq(x, y):
     return x == y or x.casefold() == y.casefold()
 
 
+def _splitroot(path):
+    try:
+        return os.path.splitroot(path)
+    except AttributeError:
+        import ntpath
+        drive, rest = ntpath.splitdrive(path)
+        if rest.startswith('\\') or rest.startswith('/'):
+            return drive, rest[0], rest[1:]
+        return drive, '', rest
+
+
 class PurePath:
     def __init__(self, *parts):
         total = ""
@@ -28,7 +39,7 @@ class PurePath:
                 total += "\\" + p
             else:
                 total += p
-        drive, root, tail = os.path.splitroot(total)
+        drive, root, tail = _splitroot(total)
         parent, _, name = tail.rpartition("\\")
         self._parent = drive + root + parent
         self.name = name
@@ -72,7 +83,7 @@ class PurePath:
 
     @property
     def parts(self):
-        drive, root, tail = os.path.splitroot(self._p)
+        drive, root, tail = _splitroot(self._p)
         bits = []
         if drive or root:
             bits.append(drive + root)
@@ -120,7 +131,7 @@ class PurePath:
         return type(self)("\\".join(parts[len(base):]))
 
     def as_uri(self):
-        drive, root, tail = os.path.splitroot(self._p)
+        drive, root, tail = _splitroot(self._p)
         if drive[1:2] == ":" and root:
             return "file:///" + self._p.replace("\\", "/")
         if drive[:2] == "\\\\":

--- a/src/manage/urlutils.py
+++ b/src/manage/urlutils.py
@@ -294,7 +294,15 @@ def _powershell_urlretrieve(request):
 $url = $env:PYMANAGER_URL
 $outfile = $env:PYMANAGER_OUTFILE
 $method = $env:PYMANAGER_METHOD
-$headers = ConvertFrom-Json $env:PYMANAGER_HEADERS
+$headersObj = ConvertFrom-Json $env:PYMANAGER_HEADERS
+$headers = @{}
+if ($headersObj -ne $null) {
+    $headersObj.PSObject.Properties | ForEach-Object {
+        $name = $_.Name
+        $value = $_.Value
+        $headers[$name] = if ($value -eq $null) { "" } else { $value.ToString() }
+    }
+}
 $r = Invoke-WebRequest -Uri $url -UseBasicParsing `
     -Headers $headers `
     -UseDefaultCredentials `


### PR DESCRIPTION
### Description

This PR addresses a critical failure in the PowerShell-based download fallback and restores compatibility for systems running Python versions earlier than 3.11.

#### 1. PowerShell Header Binding Fix (`src/manage/urlutils.py`)
*   **Root Cause**: In Windows PowerShell 5.1, the `-Headers` parameter for `Invoke-WebRequest` strictly requires a `System.Collections.IDictionary` (Hashtable). When headers are passed from Python as JSON and parsed via `ConvertFrom-Json`, PowerShell returns a `PSCustomObject`, which fails the type-binding check.
*   **Fix**: The PowerShell script has been updated to manually coerce the `PSCustomObject` into a true Hashtable (`@ {}`) by iterating over its properties. This ensures the download fallback remains robust across all Windows installations.

#### 2. Python 3.10 `os.path.splitroot` Fallback (`src/manage/pathutils.py`)
*   **Root Cause**: The current `pathutils.py` reimplementation relied on `os.path.splitroot`, a function only introduced in Python 3.11. This caused immediate crashes on older stable runtimes like Python 3.10.
*   **Fix**: Implemented a `_splitroot` helper function that uses `ntpath.splitdrive` as a fallback when `os.path.splitroot` is unavailable. This maintains the project's goal of high performance with minimal imports while ensuring broad version compatibility.

#### 3. Verification Summary
*   **PowerShell Tests**: Verified that `test_powershell_urlretrieve`, `test_powershell_urlopen`, and `test_powershell_urlretrieve_auth` all pass on a Windows 10/11 environment running Python 3.10 and PowerShell 5.1.
*   **Regression Testing**: Confirmed that the fix does not interfere with the primary `urllib` or `winhttp` download paths.

---