### PR TITLE
Hash-pin action usages, minimize CI/CD permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: 'Remove existing PyManager install'
       run: |
@@ -38,7 +38,7 @@ jobs:
     # We move faster than GitHub's Python runtimes, so use NuGet instead
     # One day we can use ourselves to download Python, but not yet...
     - name: Set up NuGet
-      uses: nuget/setup-nuget@v2.0.1
+      uses: nuget/setup-nuget@323ab0502cd38fdc493335025a96c8fdb0edc71f # v2.0.1
 
     - name: Set up Python 3.14.3
       run: |
@@ -74,7 +74,7 @@ jobs:
           --cov-report xml
 
     - name: 'Upload coverage'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
       with:
         token: ${{ secrets.CODECOV_ORG_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
   PIP_VERBOSE: true
   PYMSBUILD_VERBOSE: true
 
+permissions: {}
 
 jobs:
   build:
@@ -19,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
 
     - name: 'Remove existing PyManager install'
       run: |


### PR DESCRIPTION
Hello! This addresses some findings from [zizmor](https://docs.zizmor.sh) 🙂 

TL;DR is that I've hash-pinned all actions to make them more hermetic (making it harder for an attacker who compromises an action to push code directly to you via a mutable tag or branch). I've also added a Dependabot config that'll keep actions up-to-date, with a cooldown period that'll ensure that any action changes have at least a week to bake/receive security scrutiny before they're proposed for your inclusion. Separately, I've made the permissions on your CI/CD as minimal as possible and removed a very minor source of on-disk credential persistence via `actions/checkout`.

With these changes, the only remaining default zizmor finding is this:

```
warning[secrets-outside-env]: secrets referenced without a dedicated environment
  --> ./.github/workflows/build.yml:82:20
   |
18 |   build:
   |   ----- this job
...
82 |         token: ${{ secrets.CODECOV_ORG_TOKEN }}
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ secret is accessed outside of a dedicated environment
   |
   = note: audit confidence → High

3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high
```

...which is pretty minor, but could be resolved by a maintainer by moving that credential into a dedicated deployment environment.

Separately, I have _not_ included a CI integration for zizmor in this PR. But if you're interested in one LMK and I'd be happy to do a follow up PR for it!