### PR TITLE
fix(scriptutils): fix path resolution and wildcard extraction for absolute shebangs

### DIFF
--- a/src/manage/scriptutils.py
+++ b/src/manage/scriptutils.py
@@ -48,16 +48,19 @@ def _find_shebang_command(cmd, full_cmd, *, windowed=None):
     if not sh_cmd.match("*.exe"):
         sh_cmd = sh_cmd.with_name(sh_cmd.name + ".exe")
 
-    is_wdefault = (
+    # Only apply virtual aliases and wildcard tag extraction to bare names.
+    is_name_only = not ('/' in full_cmd or '\\' in full_cmd)
+
+    is_wdefault = is_name_only and (
         sh_cmd.match("pythonw.exe")
         or sh_cmd.match("pyw.exe")
         or sh_cmd.match("pythonw3.exe")
     )
-    is_default = is_wdefault or (
+    is_default = is_wdefault or (is_name_only and (
         sh_cmd.match("python.exe")
         or sh_cmd.match("py.exe")
         or sh_cmd.match("python3.exe")
-    )
+    ))
 
     # Internal logic error, but non-fatal, if it has no value
     assert windowed is not None
@@ -76,7 +79,8 @@ def _find_shebang_command(cmd, full_cmd, *, windowed=None):
 
     for i in cmd.get_installs():
         for a in i.get("alias", ()):
-            if sh_cmd.match(a["name"]):
+            # Only match aliases against bare names
+            if is_name_only and sh_cmd.match(a["name"]):
                 exe = a["target"]
                 LOGGER.debug("Matched alias %s in %s", a["name"], i["id"])
                 if windowed and not a.get("windowed"):
@@ -85,20 +89,27 @@ def _find_shebang_command(cmd, full_cmd, *, windowed=None):
                         exe = target[0]["target"]
                         LOGGER.debug("Substituting target %s for windowed=1", exe)
                 return {**i, "executable": i["prefix"] / exe}
-        if sh_cmd.full_match(PurePath(i["executable"]).name):
+        # Only match raw executable names against bare names
+        if is_name_only and sh_cmd.full_match(PurePath(i["executable"]).name):
             LOGGER.debug("Matched executable name %s in %s", i["executable"], i["id"])
             return i
+        # Ensure absolute shebang paths don't incorrectly match relative executable
+        # paths
         if sh_cmd.match(i["executable"]):
+            if not is_name_only and not PurePath(i["executable"]).is_absolute():
+                continue
             LOGGER.debug("Matched executable %s in %s", i["executable"], i["id"])
             return i
 
-    # Fallback search for 'python[w]<TAG>.exe' shebangs
-    if sh_cmd.match("pythonw*.exe"):
-        tag = sh_cmd.name[7:-4]
-        return cmd.get_install_to_run(f"PythonCore/{tag}", windowed=True)
-    if sh_cmd.match("python*.exe"):
-        tag = sh_cmd.name[6:-4]
-        return cmd.get_install_to_run(f"PythonCore/{tag}", windowed=windowed)
+    # Fallback search for 'python[w]<TAG>.exe' shebangs and prevent absolute paths
+    # from being blindly sliced
+    if is_name_only:
+        if sh_cmd.match("pythonw*.exe"):
+            tag = sh_cmd.name[7:-4]
+            return cmd.get_install_to_run(f"PythonCore/{tag}", windowed=True)
+        if sh_cmd.match("python*.exe"):
+            tag = sh_cmd.name[6:-4]
+            return cmd.get_install_to_run(f"PythonCore/{tag}", windowed=windowed)
 
     raise LookupError
 


### PR DESCRIPTION
## Description

This PR resolves a critical issue where scripts utilizing absolute or explicit relative shebangs (such as those generated by modern virtual environment managers like `uv`) are incorrectly intercepted, truncated, or routed to the wrong interpreter.

### 🐛 The Bugs

The original logic in `_find_shebang_command` heavily relied on `pathlib.PurePath.match()`. Because `match()` performs a loose right-aligned suffix match, `PurePath("C:/uv/python.exe").match("python.exe")` evaluates to `True`. This caused a chain reaction of unintended behaviors:

1. **The `is_default` Trap:** Absolute paths like `C:\...\python.exe` incorrectly triggered the `is_default` check, discarding the user's isolated environment and defaulting to the system-wide global Python.
2. **The Wildcard Slicing Bug:** The fallback check for `python*.exe` would intercept executables like `C:\...\python_uv_test.exe` and blindly slice the name (`[6:-4]`), causing the system to search for a phantom runtime tag (e.g., `[ERROR] No runtime installed that matches _uv_test`) and crash.
3. **Relative Execution Trap:** `sh_cmd.match(i["executable"])` could falsely intercept absolute shebangs if a registered runtime was using a relative executable name.

### 🛠️ The Fix

- **`is_name_only` Check:** Introduced a check for path separators (`/` or `\`) to properly distinguish between "bare names" (like `py.exe` or `python3.14.exe`) and explicit paths (`C:\...\python.exe` or `./python.exe`).  
  > **NOTE**: This is significantly safer than checking `len(sh_cmd.parts) == 1`, which breaks explicit normalized relative paths (like `#!./python.exe`) by stripping the `./` and incorrectly flagging them as bare names.
- **Gated Fallbacks:** Virtual alias lookup, the `is_default` override, and the tag extraction wildcards are now safely gated behind `is_name_only`.
- **Absolute vs Relative Validation:** Added a condition (`not PurePath(i["executable"]).is_absolute()`) to prevent absolute shebangs from falsely matching relative executable registries.

### 🧪 Impact

With these changes, absolute paths are safely bypassed in the virtual lookup traps, allowing them to cleanly fall through to the `LookupError` at the end of the block. This exception is caught gracefully by `_parse_shebang`, which delegates the absolute path to `shutil.which()` under `_find_on_path()`.

This restores 100% interoperability with tools like `uv` and explicit local paths (`./python.exe`), without breaking any existing PEP 397/PEP 486 behaviors for standard bare names.