### PR TITLE
gh-346: Prompt to abort background downloads

### DIFF
--- a/src/manage/install_command.py
+++ b/src/manage/install_command.py
@@ -137,7 +137,13 @@ def download_package(cmd, install, dest, cache, *, on_progress=None, urlopen=_ur
         return None
 
     ensure_tree(dest)
-    urlretrieve(install["url"], dest, on_progress=on_progress, on_auth_request=_find_creds)
+    urlretrieve(
+        install["url"],
+        dest,
+        on_progress=on_progress,
+        on_auth_request=_find_creds,
+        on_cancel=lambda: cmd.ask_yn("Abort download?"),
+    )
     LOGGER.debug("Downloaded to %s", dest)
     return dest
 

--- a/src/manage/urlutils.py
+++ b/src/manage/urlutils.py
@@ -150,6 +150,7 @@ class _Request:
         self.proxy_settings = _proxy_settings_from_env()
         self._on_progress = None
         self._on_auth_request = None
+        self._on_cancel = None
 
     def __str__(self):
         return sanitise_url(self.url)
@@ -166,6 +167,11 @@ class _Request:
         if self.username or self.password:
             return self.username, self.password
         return None
+
+    def on_cancel(self):
+        if self._on_cancel:
+            return self._on_cancel()
+        return False
 
 
 def _bits_urlretrieve(request):
@@ -234,6 +240,18 @@ def _bits_urlretrieve(request):
                 request.on_progress(progress)
             last_progress = progress
             time.sleep(0.1)
+    except KeyboardInterrupt:
+        request.on_progress(None)
+        if job and request.on_cancel():
+            try:
+                bits_cancel(bits, job)
+            except OSError:
+                LOGGER.warn("Failed to cancel background download.")
+                LOGGER.debug("ERROR:", exc_info=True)
+            else:
+                if jobfile.is_file():
+                    unlink(jobfile)
+        raise
     except OSError as ex:
         if job:
             bits_cancel(bits, job)
@@ -542,7 +560,8 @@ def urlopen(url, method="GET", headers={}, on_progress=None, on_auth_request=Non
     raise RuntimeError("Unable to download from the internet")
 
 
-def urlretrieve(url, outfile, method="GET", headers={}, chunksize=64 * 1024, on_progress=None, on_auth_request=None):
+def urlretrieve(url, outfile, method="GET", headers={}, chunksize=64 * 1024,
+                on_progress=None, on_auth_request=None, on_cancel=None):
     scheme, sep, path = url.partition("://")
     if not sep:
         scheme = "file"
@@ -574,6 +593,7 @@ def urlretrieve(url, outfile, method="GET", headers={}, chunksize=64 * 1024, on_
     request.chunksize = chunksize
     request._on_progress = on_progress
     request._on_auth_request = on_auth_request
+    request._on_cancel = on_cancel
 
     first_error = None
 

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePath
 
 from manage import install_command as IC
 from manage import installs
+from manage.commands import BaseCommand
 from manage.exceptions import NoInstallFoundError
 from manage.logging import LOGGER
 
@@ -71,6 +72,33 @@ def test_merge_existing_index(tmp_path):
         {"id": "test-1", "url": "test-file-1.zip"},
         {"id": "test-3", "url": "test-file-3.zip"},
     ]
+
+
+def test_download_package_yes_aborts_background_download(tmp_path):
+    class Cmd:
+        force = False
+        bundled_dir = None
+        source = "https://example.com/index.json"
+        confirm = False
+        _ask = BaseCommand._ask
+        ask_yn = BaseCommand.ask_yn
+
+    def urlretrieve(url, dest, **kwargs):
+        assert url == "https://example.com/download.zip"
+        assert kwargs["on_cancel"]() is True
+        dest.write_bytes(b"download")
+
+    dest = tmp_path / "download.zip"
+    result = IC.download_package(
+        Cmd(),
+        {"url": "https://example.com/download.zip"},
+        dest,
+        {},
+        urlretrieve=urlretrieve,
+    )
+
+    assert result == dest
+    assert dest.read_bytes() == b"download"
 
 
 def test_merge_existing_index_not_found(tmp_path):

--- a/tests/test_urlutils.py
+++ b/tests/test_urlutils.py
@@ -421,6 +421,51 @@ def test_bits_urlretrieve_auth(local_withauth, tmp_path):
     assert dest.read_bytes() == b"Basic placeholder:placeholder"
 
 
+@pytest.mark.parametrize("cancel,cancel_error", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_bits_urlretrieve_keyboard_interrupt(
+    monkeypatch, tmp_path, cancel, cancel_error
+):
+    bits = object()
+    job = object()
+    cancelled = []
+    cancel_requested = []
+
+    monkeypatch.setattr(_native, "coinitialize", lambda: None)
+    monkeypatch.setattr(_native, "bits_connect", lambda: bits)
+    monkeypatch.setattr(_native, "bits_begin", lambda *a, **k: job)
+    monkeypatch.setattr(_native, "bits_serialize_job", lambda *a: b"job-id")
+
+    def bits_get_progress(*args):
+        raise KeyboardInterrupt()
+
+    def bits_cancel(*args):
+        cancelled.append(args)
+        if cancel_error:
+            raise OSError()
+
+    monkeypatch.setattr(_native, "bits_get_progress", bits_get_progress)
+    monkeypatch.setattr(_native, "bits_cancel", bits_cancel)
+
+    request = UU._Request("https://example.com/download")
+    request.outfile = tmp_path / "download.zip"
+    progress = []
+    request._on_progress = progress.append
+    request._on_cancel = lambda: cancel_requested.append(True) or cancel
+    jobfile = request.outfile.with_suffix(".job")
+
+    with pytest.raises(KeyboardInterrupt):
+        UU._bits_urlretrieve(request)
+
+    assert cancel_requested == [True]
+    assert progress == [None]
+    assert bool(cancelled) == cancel
+    assert jobfile.is_file() == (not cancel or cancel_error)
+
+
 @pytest.fixture
 def inject_error():
     try:


### PR DESCRIPTION
## Summary

- Prompt users to abort an active BITS download after pressing Ctrl+C.
- Cancel the background job automatically when confirmations are disabled with `--yes`.
- Preserve the resumable BITS job when the user declines the prompt or cancellation fails.

## Context

BITS downloads intentionally continue in the background so that an interrupted installation can reuse the completed download on retry. However, an explicit Ctrl+C indicates that the user may want to stop the background transfer as well.

As discussed in the [maintainer's design guidance](https://github.com/python/pymanager/issues/346#issuecomment-4533179369), an interactive interruption should ask whether to abort the download, while `--yes` should default to aborting it.

Currently, `KeyboardInterrupt` leaves `_bits_urlretrieve` without giving the caller an opportunity to cancel the BITS job.

Closes #346.

## Changes

### Cancellation prompt

`download_package` now supplies an optional cancellation callback to `urlretrieve`. The callback uses the existing `cmd.ask_yn(...)` confirmation mechanism, so it follows the normal command-line behavior:

- interactive execution prompts before cancelling;
- `--yes` accepts the cancellation without prompting.

### BITS interruption handling

When `_bits_urlretrieve` receives `KeyboardInterrupt`, it now:

1. clears the active progress display;
2. asks whether the background download should be aborted;
3. cancels the BITS job and removes its `.job` file when confirmed;
4. preserves the job and `.job` file when cancellation is declined;
5. preserves the `.job` file and logs a warning if BITS cannot cancel the job;
6. re-raises `KeyboardInterrupt` in every case.

Unexpected download errors retain their existing behavior. The WinHTTP, urllib, PowerShell, and local-file download paths are unchanged.

## Tests

Added deterministic coverage for:

- declining cancellation and preserving the resumable job;
- confirming cancellation and removing the job file;
- preserving the job file when BITS cancellation fails;
- resetting the progress display before prompting;
- treating `--yes` as confirmation without interactive input.

## Validation

Performed on Windows with Python 3.14.6 and pytest 9.1.1:

- focused new tests: PASS (`4 passed`);
- `tests/test_urlutils.py` and `tests/test_install_command.py`: PASS (`78 passed`);
- `git diff --check`: PASS.

The BITS interruption tests inject `KeyboardInterrupt` at the progress polling boundary. A manual interactive Ctrl+C test against a live background download was not performed.

## Compatibility and risk

The new `on_cancel` callback is optional, so existing `urlretrieve` callers retain their previous behavior. Only the BITS download path consults it after `KeyboardInterrupt`; normal downloads and fallback selection are unaffected.

The job metadata is removed only after `bits_cancel` succeeds. This avoids losing the ability to resume a background job when cancellation fails.
