### PR TITLE
Include ARM64 package in fallback index

### DIFF
--- a/make.py
+++ b/make.py
@@ -42,7 +42,7 @@ run([sys.executable, "-m", "pymsbuild", "wheel"],
     env={**os.environ, "BUILD_SOURCEBRANCH": ref})
 
 # Bundle current latest release
-run([LAYOUT / "py-manager.exe", "install", "-v", "-f", "--download", TEMP / "bundle", "default"])
+run([LAYOUT / "py-manager.exe", "install", "-v", "-f", "--download", TEMP / "bundle", "3-64", "3-arm64"])
 (LAYOUT / "bundled").mkdir(parents=True, exist_ok=True)
 (TEMP / "bundle" / "index.json").rename(LAYOUT / "bundled" / "fallback-index.json")
 for f in (TEMP / "bundle").iterdir():


### PR DESCRIPTION
This may need to lead to a future re-think of how to include bundled runtimes, but now that we have two potential offline defaults we either need to let ARM64 OS default to x64 builds (which would work okay-ish) or start producing two packages and make users choose the right one ahead of time (also barely okay-ish).

In the meantime, having both packages seems like the least bad option right now. Most of the extra size is unfortunately two (zipped) copies of the docs, but until we decide that the docs don't need to be installed at all, that's unavoidable.